### PR TITLE
improve the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ test branch and run clang-format on the patch context.
 - Run `perl ./scripts/applypatch.pl --clang-format {patchfile}` (replace 'patchfile' with your patchfile).<br/>
 - This will format the changes made using clang-format and apply it on top of a new branch("test-{your_current_branch}").<br/>
 You can provide your own branch name using `--branch={branch_name}` option.
-- Also a modified patchfile will be created alongside your pathfile with suffix `.EXPERIMENTAL-clang_format-fixes`.
+- A single diff with all the changes will be created clang-formatted at `clang-format-fixes.diff`
+- Future Plan: A modified patchfile will be created alongside each pathfile with suffix `.EXPERIMENTAL-clang_format-fixes`.
 
 ### Pre-requisite for this script:
 
 - The patchfile should be applicable to the recent state of the branch.
-- This script is dependent on `clang-format-8` to function properly.<br/>
-Any version less than 8 is dependent on python2 and the latest Terminals(atleast for Ubuntu 18.04) are dependent on python3. So changing Python version for running the script may not be a great option.
+- This script is dependent on `clang-format-diff` to function properly.<br/>


### PR DESCRIPTION
- check if the patch applies before applying it
- remove the user's need to enter file path for clang-format-diff
- fix python version dependency with respect to clang-format version.
Detect required python version automatically
- Do not run clang-format if patch application fails
- Update Readme appropriately